### PR TITLE
Issue #41: Remove left/right padding. Use margin for messages.

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -354,7 +354,7 @@
 }
 
 .layout .l-messages {
-  padding: 0 2rem 2rem;
+  margin: 2rem 0;
 }
 
 .l-footer {


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/basis/issues/41.
